### PR TITLE
🔨 Dependencies: add nonotation package as submodule 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dependencies"]
+	path = dependencies
+	url = https://github.com/Project2100/math-nonotation.git

--- a/latexmkrc
+++ b/latexmkrc
@@ -1,0 +1,1 @@
+ensure_path( 'TEXINPUTS', './dependencies//' );

--- a/main.tex
+++ b/main.tex
@@ -17,7 +17,7 @@
 \usepackage{pifont} % Hyperlink dingbat
 \newcommand{\linkicon}{\ding{226}}
 
-\usepackage{dependencies/nonotation}
+\usepackage{nonotation}
 \usepackage{tikz}
 \usetikzlibrary{arrows.meta}
 

--- a/main.tex
+++ b/main.tex
@@ -17,7 +17,7 @@
 \usepackage{pifont} % Hyperlink dingbat
 \newcommand{\linkicon}{\ding{226}}
 
-\usepackage{nonotation}
+\usepackage{dependencies/nonotation}
 \usepackage{tikz}
 \usetikzlibrary{arrows.meta}
 
@@ -44,57 +44,57 @@
 
 \begin{document}
 
-    \tableofcontents
+\tableofcontents
 
-    \chapter{Introduction}
+\chapter{Introduction}
 
-    Cryptography is the collection of techniques that are designed to enable secure communication between two parties in a setting where third parties intend to listen and/or modify the transmitted information. While encryption schemes are usually the first thing that come to mind, it is worthwhile to carefully consider all the aspects that cryptography influences:
+Cryptography is the collection of techniques that are designed to enable secure communication between two parties in a setting where third parties intend to listen and/or modify the transmitted information. While encryption schemes are usually the first thing that come to mind, it is worthwhile to carefully consider all the aspects that cryptography influences:
 
-    \begin{itemize}
-        \item \emph{Confidentiality}: the two parties can safely assume that they are communicating privately; this can be further split into:
-        \begin{itemize}
-            \item \emph{Secrecy}: the aspect of communication privacy;
-            \item \emph{Authentication}: the aspect of party identity verification.
-        \end{itemize}
+\begin{itemize}
+    \item \emph{Confidentiality}: the two parties can safely assume that they are communicating privately; this can be further split into:
+          \begin{itemize}
+              \item \emph{Secrecy}: the aspect of communication privacy;
+              \item \emph{Authentication}: the aspect of party identity verification.
+          \end{itemize}
 
-        \item \emph{Integrity}: Some techniques employed here are also designed to ensure that the transmitted data is not altered, a property of which desirabiliy is paramount in safety-critical scenarios.
-    \end{itemize}
+    \item \emph{Integrity}: Some techniques employed here are also designed to ensure that the transmitted data is not altered, a property of which desirabiliy is paramount in safety-critical scenarios.
+\end{itemize}
 
-    Modern cryptography systems are usually designed according to \emph{Kerckhoffs's principle}, which states that a secure system shall only rely on the encryption keys, and not by the secrecy of the underlying algorithm; as Claude Shannon later summed up: \emph{``the enemy knows the scheme''}. The problem of sharing the key between two parties while retaining communication confidentiality thus becomes central in developing a good scheme, and is the main focus of almost every scheme described here.
+Modern cryptography systems are usually designed according to \emph{Kerckhoffs's principle}, which states that a secure system shall only rely on the encryption keys, and not by the secrecy of the underlying algorithm; as Claude Shannon later summed up: \emph{``the enemy knows the scheme''}. The problem of sharing the key between two parties while retaining communication confidentiality thus becomes central in developing a good scheme, and is the main focus of almost every scheme described here.
 
-    \part{Mathematical foundations}
-    
-    \input{lessons/lesson_1.tex}
-    \input{lessons/lesson_2.tex}
-    \input{lessons/lesson_3.tex}
-    \input{lessons/lesson_4.tex}
-    \input{lessons/lesson_5.tex}
-    \input{lessons/lesson_6.tex}
-    \input{lessons/lesson_7.tex}
+\part{Mathematical foundations}
 
-    \part{Symmetric schemes}
+\input{lessons/lesson_1.tex}
+\input{lessons/lesson_2.tex}
+\input{lessons/lesson_3.tex}
+\input{lessons/lesson_4.tex}
+\input{lessons/lesson_5.tex}
+\input{lessons/lesson_6.tex}
+\input{lessons/lesson_7.tex}
 
-    \input{lessons/lesson_8.tex}
-    \input{lessons/lesson_9.tex}
-    \input{lessons/lesson_10.tex}
-    \input{lessons/lesson_11.tex}
-    \input{lessons/lesson_12.tex}
+\part{Symmetric schemes}
 
-    \part{Asymmetric schemes}
+\input{lessons/lesson_8.tex}
+\input{lessons/lesson_9.tex}
+\input{lessons/lesson_10.tex}
+\input{lessons/lesson_11.tex}
+\input{lessons/lesson_12.tex}
 
-    \input{lessons/lesson_13.tex}
-    \input{lessons/lesson_14.tex}
-    \input{lessons/lesson_15.tex}
-    \input{lessons/lesson_16.tex}
-    \input{lessons/lesson_17.tex}
-    \input{lessons/lesson_18.tex}
-    \input{lessons/lesson_19.tex}
+\part{Asymmetric schemes}
 
-    \part{Proof-based schemes}
+\input{lessons/lesson_13.tex}
+\input{lessons/lesson_14.tex}
+\input{lessons/lesson_15.tex}
+\input{lessons/lesson_16.tex}
+\input{lessons/lesson_17.tex}
+\input{lessons/lesson_18.tex}
+\input{lessons/lesson_19.tex}
 
-    \input{lessons/lesson_20.tex}
-    \input{lessons/lesson_21.tex}
-    \input{lessons/lesson_22.tex}
-    \input{lessons/lesson_23.tex}
-    \input{lessons/lesson_24.tex}
+\part{Proof-based schemes}
+
+\input{lessons/lesson_20.tex}
+\input{lessons/lesson_21.tex}
+\input{lessons/lesson_22.tex}
+\input{lessons/lesson_23.tex}
+\input{lessons/lesson_24.tex}
 \end{document}


### PR DESCRIPTION
## Rationale

I think it would be better to add the **nonotation** package as a submodule rather than only adding a reference in the README file.
It's easier (and faster) when you clone the repository and it's less error-prone, since changes could potentially break backward compatibility.

### One last note

I have realized my local LaTeX autoformatter was enabled, so the commit includes some formatting changes to main.tex file. Clearly feel free to revert them, if you don't like it!

